### PR TITLE
Hours, minutes remaining use plural translations.

### DIFF
--- a/cbatticon.c
+++ b/cbatticon.c
@@ -893,23 +893,23 @@ static gchar* get_battery_string (gint state, gint percentage)
             break;
 
         case DISCHARGING:
-            g_snprintf (battery_string, STR_LTH, _("Battery is discharging (%i% remaining)"), percentage);
+            g_snprintf (battery_string, STR_LTH, _("Battery is discharging (%i%% remaining)"), percentage);
             break;
 
         case NOT_CHARGING:
-            g_snprintf (battery_string, STR_LTH, _("Battery is not charging (%i% remaining)"), percentage);
+            g_snprintf (battery_string, STR_LTH, _("Battery is not charging (%i%% remaining)"), percentage);
             break;
 
         case LOW_LEVEL:
-            g_snprintf (battery_string, STR_LTH, _("Battery level is low! (%i% remaining)"), percentage);
+            g_snprintf (battery_string, STR_LTH, _("Battery level is low! (%i%% remaining)"), percentage);
             break;
 
         case CRITICAL_LEVEL:
-            g_snprintf (battery_string, STR_LTH, _("Battery level is critical! (%i% remaining)"), percentage);
+            g_snprintf (battery_string, STR_LTH, _("Battery level is critical! (%i%% remaining)"), percentage);
             break;
 
         case CHARGING:
-            g_snprintf (battery_string, STR_LTH, _("Battery is charging (%i%)"), percentage);
+            g_snprintf (battery_string, STR_LTH, _("Battery is charging (%i%%)"), percentage);
             break;
 
         default:
@@ -927,6 +927,7 @@ static gchar* get_battery_string (gint state, gint percentage)
 static gchar* get_time_string (gint minutes)
 {
     static gchar time_string[STR_LTH];
+    static gchar minutes_string[STR_LTH];
     gint hours;
 
     if (minutes < 0) {
@@ -937,9 +938,10 @@ static gchar* get_time_string (gint minutes)
     minutes = minutes % 60;
 
     if (hours > 0) {
-        g_sprintf (time_string, _("%2d hours, %2d minutes remaining"), hours, minutes);
+        g_sprintf (minutes_string, ngettext("%2d minute", "%2d minutes", minutes), minutes);
+        g_sprintf (time_string, ngettext("%2d hour, %s remaining", "%2d hours, %s remaining", hours), hours, minutes_string);
     } else {
-        g_sprintf (time_string, _("%2d minutes remaining"), minutes);
+        g_sprintf (time_string, ngettext("%2d minute remaining", "%2d minutes remaining", minutes), minutes);
     }
 
     if (configuration.debug_output == TRUE) {

--- a/cbatticon.pot
+++ b/cbatticon.pot
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n!=1;\n"
 
 #: cbatticon.c:154
 msgid "Display the version"
@@ -65,224 +66,240 @@ msgstr ""
 msgid "[BATTERY ID]"
 msgstr ""
 
-#: cbatticon.c:175
+#: cbatticon.c:174
 #, c-format
 msgid "Cannot parse command line arguments: %s\n"
 msgstr ""
 
-#: cbatticon.c:186
+#: cbatticon.c:185
 msgid ""
 "cbatticon: a lightweight and fast battery icon that sits in your system "
 "tray\n"
 msgstr ""
 
-#: cbatticon.c:187
+#: cbatticon.c:186
 #, c-format
 msgid "version %s\n"
 msgstr ""
 
-#: cbatticon.c:195
+#: cbatticon.c:194
 msgid "List of available power supplies:\n"
 msgstr ""
 
-#: cbatticon.c:208
+#: cbatticon.c:209
 msgid "List of available icon types:\n"
 msgstr ""
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212
 msgid "available"
 msgstr ""
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211 cbatticon.c:539
-#: cbatticon.c:547 cbatticon.c:569
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212 cbatticon.c:540
+#: cbatticon.c:548 cbatticon.c:570
 msgid "unavailable"
 msgstr ""
 
-#: cbatticon.c:225
+#: cbatticon.c:226
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr ""
 
-#: cbatticon.c:237
+#: cbatticon.c:238
 msgid "No icon type found!\n"
 msgstr ""
 
-#: cbatticon.c:244
+#: cbatticon.c:245
 #, c-format
 msgid "Invalid update interval! It has been reset to default (%d seconds)\n"
 msgstr ""
 
-#: cbatticon.c:251
+#: cbatticon.c:252
 #, c-format
 msgid "Invalid low level! It has been reset to default (%d percent)\n"
 msgstr ""
 
-#: cbatticon.c:256
+#: cbatticon.c:257
 #, c-format
 msgid "Invalid critical level! It has been reset to default (%d percent)\n"
 msgstr ""
 
-#: cbatticon.c:262
+#: cbatticon.c:263
 msgid ""
 "Critical level is higher than low level! They have been reset to default\n"
 msgstr ""
 
-#: cbatticon.c:293 cbatticon.c:325
+#: cbatticon.c:294 cbatticon.c:326
 #, c-format
 msgid "type: %-*.*s\tid: %-*.*s\tpath: %s\n"
 msgstr ""
 
-#: cbatticon.c:293
+#: cbatticon.c:294
 msgid "Battery"
 msgstr ""
 
-#: cbatticon.c:310
+#: cbatticon.c:311
 msgid "workaround: current rate is not available, estimating rate\n"
 msgstr ""
 
-#: cbatticon.c:315
+#: cbatticon.c:316
 #, c-format
 msgid "battery path: %s\n"
 msgstr ""
 
-#: cbatticon.c:325
+#: cbatticon.c:326
 msgid "AC"
 msgstr ""
 
-#: cbatticon.c:333
+#: cbatticon.c:334
 #, c-format
 msgid "ac path: %s\n"
 msgstr ""
 
-#: cbatticon.c:347
+#: cbatticon.c:348
 #, c-format
 msgid "Cannot open sysfs directory: %s (%s)\n"
 msgstr ""
 
-#: cbatticon.c:354
+#: cbatticon.c:355
 #, c-format
 msgid "No battery with suffix %s found!\n"
 msgstr ""
 
-#: cbatticon.c:359
+#: cbatticon.c:360
 msgid "No battery nor AC power supply found!\n"
 msgstr ""
 
-#: cbatticon.c:424
+#: cbatticon.c:425
 #, c-format
 msgid "battery present: %s"
 msgstr ""
 
-#: cbatticon.c:454
+#: cbatticon.c:455
 #, c-format
 msgid "battery status: %d - %s"
 msgstr ""
 
-#: cbatticon.c:479
+#: cbatticon.c:480
 #, c-format
 msgid "ac online: %s"
 msgstr ""
 
-#: cbatticon.c:539
+#: cbatticon.c:540
 #, c-format
 msgid "full capacity: %s\n"
 msgstr ""
 
-#: cbatticon.c:547
+#: cbatticon.c:548
 #, c-format
 msgid "remaining capacity: %s\n"
 msgstr ""
 
-#: cbatticon.c:569
+#: cbatticon.c:570
 #, c-format
 msgid "current rate: %s\n"
 msgstr ""
 
-#: cbatticon.c:671 cbatticon.c:674
+#: cbatticon.c:672 cbatticon.c:675
 msgid "AC only, no battery!"
 msgstr ""
 
-#: cbatticon.c:792
+#: cbatticon.c:793
 #, c-format
 msgid "Spawning critical battery level command in 30 seconds: %s"
 msgstr ""
 
-#: cbatticon.c:796
+#: cbatticon.c:797
 #, c-format
 msgid "Cannot spawn critical battery level command: %s"
 msgstr ""
 
-#: cbatticon.c:799
+#: cbatticon.c:800
 msgid "Cannot spawn critical battery level command!"
 msgstr ""
 
-#: cbatticon.c:816
+#: cbatticon.c:817
 #, c-format
 msgid "Cannot spawn left click command: %s"
 msgstr ""
 
-#: cbatticon.c:819
+#: cbatticon.c:820
 msgid "Cannot spawn left click command!"
 msgstr ""
 
-#: cbatticon.c:862 cbatticon.c:870
+#: cbatticon.c:863 cbatticon.c:871
 #, c-format
 msgid "tooltip: %s\n"
 msgstr ""
 
-#: cbatticon.c:883
+#: cbatticon.c:884
 msgid "Battery is missing!"
 msgstr ""
 
-#: cbatticon.c:887
+#: cbatticon.c:888
 msgid "Battery status is unknown!"
 msgstr ""
 
-#: cbatticon.c:891
+#: cbatticon.c:892
 msgid "Battery is charged!"
 msgstr ""
 
-#: cbatticon.c:895
-msgid "Battery is discharging (%i% remaining)"
+#: cbatticon.c:896
+#, c-format
+msgid "Battery is discharging (%i%% remaining)"
 msgstr ""
 
-#: cbatticon.c:899
-msgid "Battery is not charging (%i% remaining)"
+#: cbatticon.c:900
+#, c-format
+msgid "Battery is not charging (%i%% remaining)"
 msgstr ""
 
-#: cbatticon.c:903
-msgid "Battery level is low! (%i% remaining)"
+#: cbatticon.c:904
+#, c-format
+msgid "Battery level is low! (%i%% remaining)"
 msgstr ""
 
-#: cbatticon.c:907
-msgid "Battery level is critical! (%i% remaining)"
+#: cbatticon.c:908
+#, c-format
+msgid "Battery level is critical! (%i%% remaining)"
 msgstr ""
 
-#: cbatticon.c:911
-msgid "Battery is charging (%i%)"
+#: cbatticon.c:912
+#, c-format
+msgid "Battery is charging (%i%%)"
 msgstr ""
 
-#: cbatticon.c:920
+#: cbatticon.c:921
 #, c-format
 msgid "battery string: %s\n"
 msgstr ""
 
-#: cbatticon.c:939
-#, c-format
-msgid "%2d hours, %2d minutes remaining"
-msgstr ""
-
 #: cbatticon.c:941
 #, c-format
-msgid "%2d minutes remaining"
-msgstr ""
+msgid "%2d minute"
+msgid_plural "%2d minutes"
+msgstr[0] ""
+msgstr[1] ""
 
-#: cbatticon.c:945
+#: cbatticon.c:942
+#, c-format
+msgid "%2d hour, %s remaining"
+msgid_plural "%2d hours, %s remaining"
+msgstr[0] ""
+msgstr[1] ""
+
+#: cbatticon.c:944
+#, c-format
+msgid "%2d minute remaining"
+msgid_plural "%2d minutes remaining"
+msgstr[0] ""
+msgstr[1] ""
+
+#: cbatticon.c:948
 #, c-format
 msgid "time string: %s\n"
 msgstr ""
 
-#: cbatticon.c:993
+#: cbatticon.c:996
 #, c-format
 msgid "icon name: %s\n"
 msgstr ""

--- a/de.po
+++ b/de.po
@@ -7,15 +7,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: cbatticon 1.5.0\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: valere.monseur@ymail.com\n"
 "POT-Creation-Date: 2015-07-17 20:38+0200\n"
 "PO-Revision-Date: 2015-07-19 17:35+0200\n"
 "Last-Translator: Julian Ospald <hasufell@gentoo.org>\n"
-"Language-Team: N/A\\n"
+"Language-Team: N/A\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n!=1;\n"
 
 #: cbatticon.c:154
 msgid "Display the version"
@@ -65,225 +66,251 @@ msgstr "Verfügbare Stromversorgungsgeräte auflisten (Batterie und AC)"
 msgid "[BATTERY ID]"
 msgstr "[BATTERIE ID]"
 
-#: cbatticon.c:175
+#: cbatticon.c:174
 #, c-format
 msgid "Cannot parse command line arguments: %s\n"
 msgstr "Kann Kommandozeilen-Argumente nicht parsen: %s\n"
 
-#: cbatticon.c:186
+#: cbatticon.c:185
 msgid ""
 "cbatticon: a lightweight and fast battery icon that sits in your system "
 "tray\n"
-msgstr "cbatticon: ein leichtgewichtiges und schnelles Batteriesymbol, das in der System-Tray sitzt\n"
+msgstr ""
+"cbatticon: ein leichtgewichtiges und schnelles Batteriesymbol, das in der "
+"System-Tray sitzt\n"
 
-#: cbatticon.c:187
+#: cbatticon.c:186
 #, c-format
 msgid "version %s\n"
 msgstr "Version %s\n"
 
-#: cbatticon.c:195
+#: cbatticon.c:194
 msgid "List of available power supplies:\n"
 msgstr "Verfügbare Stromversorgungsgeräte auflisten:\n"
 
-#: cbatticon.c:208
+#: cbatticon.c:209
 msgid "List of available icon types:\n"
 msgstr "Verfügbare Symboltypen auflisten:\n"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212
 msgid "available"
 msgstr "verfügbar"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211 cbatticon.c:539
-#: cbatticon.c:547 cbatticon.c:569
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212 cbatticon.c:540
+#: cbatticon.c:548 cbatticon.c:570
 msgid "unavailable"
 msgstr "nicht verfügbar"
 
-#: cbatticon.c:225
+#: cbatticon.c:226
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Unbekannter Symboltyp: %s\n"
 
-#: cbatticon.c:237
+#: cbatticon.c:238
 msgid "No icon type found!\n"
 msgstr "Kein Symboltyp gefunden!\n"
 
-#: cbatticon.c:244
+#: cbatticon.c:245
 #, c-format
 msgid "Invalid update interval! It has been reset to default (%d seconds)\n"
-msgstr "Ungültiges Update-Intervall! Wird auf Voreinstellung zurückgesetzt (%d Sekunden)\n"
+msgstr ""
+"Ungültiges Update-Intervall! Wird auf Voreinstellung zurückgesetzt (%d "
+"Sekunden)\n"
 
-#: cbatticon.c:251
+#: cbatticon.c:252
 #, c-format
 msgid "Invalid low level! It has been reset to default (%d percent)\n"
-msgstr "Ungültige Einstellung für niedrigen Batteriestand! Wird auf Voreinstellung zurückgesetzt (%d Prozent)\n"
+msgstr ""
+"Ungültige Einstellung für niedrigen Batteriestand! Wird auf Voreinstellung "
+"zurückgesetzt (%d Prozent)\n"
 
-#: cbatticon.c:256
+#: cbatticon.c:257
 #, c-format
 msgid "Invalid critical level! It has been reset to default (%d percent)\n"
-msgstr "Ungültige Einstellung für kritischen Batteriestand! Wird auf Voreinstellung zurückgesetzt (%d Prozent)\n"
+msgstr ""
+"Ungültige Einstellung für kritischen Batteriestand! Wird auf Voreinstellung "
+"zurückgesetzt (%d Prozent)\n"
 
-#: cbatticon.c:262
+#: cbatticon.c:263
 msgid ""
 "Critical level is higher than low level! They have been reset to default\n"
 msgstr ""
-"Einstellung für kritischen Batteriestand ist höher als für niedrigen. Beide werden auf die Voreinstellungen zurückgesetzt\n"
+"Einstellung für kritischen Batteriestand ist höher als für niedrigen. Beide "
+"werden auf die Voreinstellungen zurückgesetzt\n"
 
-#: cbatticon.c:293 cbatticon.c:325
+#: cbatticon.c:294 cbatticon.c:326
 #, c-format
 msgid "type: %-*.*s\tid: %-*.*s\tpath: %s\n"
 msgstr "Typ: %-*.*s\tID: %-*.*s\tPfad: %s\n"
 
-#: cbatticon.c:293
+#: cbatticon.c:294
 msgid "Battery"
 msgstr "Batterie"
 
-#: cbatticon.c:310
+#: cbatticon.c:311
 msgid "workaround: current rate is not available, estimating rate\n"
 msgstr "Workaround: aktuelle Rate ist nicht verfügbar, Rate wird geschätzt\n"
 
-#: cbatticon.c:315
+#: cbatticon.c:316
 #, c-format
 msgid "battery path: %s\n"
 msgstr "Batterie-Pfad: %s\n"
 
-#: cbatticon.c:325
+#: cbatticon.c:326
 msgid "AC"
 msgstr "AC"
 
-#: cbatticon.c:333
+#: cbatticon.c:334
 #, c-format
 msgid "ac path: %s\n"
 msgstr "AC Pfad: %s\n"
 
-#: cbatticon.c:347
+#: cbatticon.c:348
 #, c-format
 msgid "Cannot open sysfs directory: %s (%s)\n"
 msgstr "Kann sysfs Ordner nicht öffnen: %s (%s)\n"
 
-#: cbatticon.c:354
+#: cbatticon.c:355
 #, c-format
 msgid "No battery with suffix %s found!\n"
 msgstr "Keine Batterie mit Suffix %s gefunden!\n"
 
-#: cbatticon.c:359
+#: cbatticon.c:360
 msgid "No battery nor AC power supply found!\n"
 msgstr "Keine Batterie oder AC Stromversorgung gefunden!\n"
 
-#: cbatticon.c:424
+#: cbatticon.c:425
 #, c-format
 msgid "battery present: %s"
 msgstr "Batterie vorhanden: %s"
 
-#: cbatticon.c:454
+#: cbatticon.c:455
 #, c-format
 msgid "battery status: %d - %s"
 msgstr "Batteriestatus: %d - %s"
 
-#: cbatticon.c:479
+#: cbatticon.c:480
 #, c-format
 msgid "ac online: %s"
 msgstr "AC angeschlossen: %s"
 
-#: cbatticon.c:539
+#: cbatticon.c:540
 #, c-format
 msgid "full capacity: %s\n"
 msgstr "volle Kapazität: %s\n"
 
-#: cbatticon.c:547
+#: cbatticon.c:548
 #, c-format
 msgid "remaining capacity: %s\n"
 msgstr "verbleibende Kapazität: %s\n"
 
-#: cbatticon.c:569
+#: cbatticon.c:570
 #, c-format
 msgid "current rate: %s\n"
 msgstr "aktuelle Rate: %s\n"
 
-#: cbatticon.c:671 cbatticon.c:674
+#: cbatticon.c:672 cbatticon.c:675
 msgid "AC only, no battery!"
 msgstr "Nur AC, keine Batterie!"
 
-#: cbatticon.c:792
+#: cbatticon.c:793
 #, c-format
 msgid "Spawning critical battery level command in 30 seconds: %s"
-msgstr "Befehl für kritischen Batteriezustand wird in 30 Sekunden aufgerufen: %s"
+msgstr ""
+"Befehl für kritischen Batteriezustand wird in 30 Sekunden aufgerufen: %s"
 
-#: cbatticon.c:796
+#: cbatticon.c:797
 #, c-format
 msgid "Cannot spawn critical battery level command: %s"
 msgstr "Kann Befehl für kritischen Batteriezustand nicht aufrufen: %s"
 
-#: cbatticon.c:799
+#: cbatticon.c:800
 msgid "Cannot spawn critical battery level command!"
 msgstr "Kann Befehl für kritischen Batteriezustand nicht aufrufen!"
 
-#: cbatticon.c:816
+#: cbatticon.c:817
 #, c-format
 msgid "Cannot spawn left click command: %s"
 msgstr "Kann Befehl für Linksklick nicht aufrufen: %s"
 
-#: cbatticon.c:819
+#: cbatticon.c:820
 msgid "Cannot spawn left click command!"
 msgstr "Kann Befehl für Linksklick nicht aufrufen!"
 
-#: cbatticon.c:862 cbatticon.c:870
+#: cbatticon.c:863 cbatticon.c:871
 #, c-format
 msgid "tooltip: %s\n"
 msgstr "Tooltip: %s\n"
 
-#: cbatticon.c:883
+#: cbatticon.c:884
 msgid "Battery is missing!"
 msgstr "Batterie fehlt!"
 
-#: cbatticon.c:887
+#: cbatticon.c:888
 msgid "Battery status is unknown!"
 msgstr "Batteriezustand unbekannt!"
 
-#: cbatticon.c:891
+#: cbatticon.c:892
 msgid "Battery is charged!"
 msgstr "Batterie ist vollständig aufgeladen!"
 
-#: cbatticon.c:895
-msgid "Battery is discharging (%i% remaining)"
-msgstr "Batterie entlädt (%i% verbleibend)"
+#: cbatticon.c:896
+#, fuzzy, c-format
+msgid "Battery is discharging (%i%% remaining)"
+msgstr "Batterie entlädt (%i%% verbleibend)"
 
-#: cbatticon.c:899
-msgid "Battery is not charging (%i% remaining)"
-msgstr "Batterie lädt nicht auf (%i% verbleibend)"
+#: cbatticon.c:900
+#, fuzzy, c-format
+msgid "Battery is not charging (%i%% remaining)"
+msgstr "Batterie lädt nicht auf (%i%% verbleibend)"
 
-#: cbatticon.c:903
-msgid "Battery level is low! (%i% remaining)"
-msgstr "Batteriezustand niedrig! (%i% verbleibend)"
+#: cbatticon.c:904
+#, fuzzy, c-format
+msgid "Battery level is low! (%i%% remaining)"
+msgstr "Batteriezustand niedrig! (%i%% verbleibend)"
 
-#: cbatticon.c:907
-msgid "Battery level is critical! (%i% remaining)"
-msgstr "Batteriezustand kritisch! (%i% verbleibend)"
+#: cbatticon.c:908
+#, fuzzy, c-format
+msgid "Battery level is critical! (%i%% remaining)"
+msgstr "Batteriezustand kritisch! (%i%% verbleibend)"
 
-#: cbatticon.c:911
-msgid "Battery is charging (%i%)"
-msgstr "Batterie lädt auf (%i%)"
+#: cbatticon.c:912
+#, fuzzy, c-format
+msgid "Battery is charging (%i%%)"
+msgstr "Batterie lädt auf (%i%%)"
 
-#: cbatticon.c:920
+#: cbatticon.c:921
 #, c-format
 msgid "battery string: %s\n"
 msgstr "Batteriemeldung: %s\n"
 
-#: cbatticon.c:939
-#, c-format
-msgid "%2d hours, %2d minutes remaining"
-msgstr "%2d Stunden, %2d Minuten verbleibend"
-
 #: cbatticon.c:941
-#, c-format
-msgid "%2d minutes remaining"
-msgstr "%2d Minuten verbleibend"
+#, fuzzy, c-format
+msgid "%2d minute"
+msgid_plural "%2d minutes"
+msgstr[0] "%2d Minute"
+msgstr[1] "%2d Minuten"
 
-#: cbatticon.c:945
+#: cbatticon.c:942
+#, fuzzy, c-format
+msgid "%2d hour, %s remaining"
+msgid_plural "%2d hours, %s remaining"
+msgstr[0] "%2d Stunde, %s verbleibend"
+msgstr[1] "%2d Stunden, %s verbleibend"
+
+#: cbatticon.c:944
+#, fuzzy, c-format
+msgid "%2d minute remaining"
+msgid_plural "%2d minutes remaining"
+msgstr[0] "%2d Minute verbleibend"
+msgstr[1] "%2d Minuten verbleibend"
+
+#: cbatticon.c:948
 #, c-format
 msgid "time string: %s\n"
 msgstr "Zeitmeldung: %s\n"
 
-#: cbatticon.c:993
+#: cbatticon.c:996
 #, c-format
 msgid "icon name: %s\n"
 msgstr "Symbolname: %s\n"

--- a/fr.po
+++ b/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cbatticon 1.5.0\n"
 "Report-Msgid-Bugs-To: valere.monseur@ymail.com\n"
-"POT-Creation-Date: 2015-07-17 20:09+0200\n"
+"POT-Creation-Date: 2015-07-17 20:38+0200\n"
 "PO-Revision-Date: 2015-07-17 20:09+0200\n"
 "Last-Translator: Valère Monseur <valere.monseur@ymail.com>\n"
 "Language-Team: N/A\n"
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
 
 #: cbatticon.c:154
 msgid "Display the version"
@@ -43,11 +44,14 @@ msgstr "Définir le niveau de charge critique (en pourcent)"
 
 #: cbatticon.c:160
 msgid "Command to execute when critical battery level is reached"
-msgstr "Commande à exécuter lorsque le niveau critique de la batterie est atteint"
+msgstr ""
+"Commande à exécuter lorsque le niveau critique de la batterie est atteint"
 
 #: cbatticon.c:161
 msgid "Command to execute when left clicking on tray icon"
-msgstr "Commande à exécuter lors d'un clic gauche sur l'icône de la barre d'état systême"
+msgstr ""
+"Commande à exécuter lors d'un clic gauche sur l'icône de la barre d'état "
+"systême"
 
 #: cbatticon.c:163
 msgid "Hide the notification popups"
@@ -65,229 +69,255 @@ msgstr "Lister les alimentations disponibles (batterie et secteur)"
 msgid "[BATTERY ID]"
 msgstr "[ID BATTERIE]"
 
-#: cbatticon.c:175
+#: cbatticon.c:174
 #, c-format
 msgid "Cannot parse command line arguments: %s\n"
 msgstr "Impossible d'analyser les paramètres de la ligne de commande: %s\n"
 
-#: cbatticon.c:186
+#: cbatticon.c:185
 msgid ""
 "cbatticon: a lightweight and fast battery icon that sits in your system "
 "tray\n"
-msgstr "cbatticon: une icône d'affichage de la batterie, légère et rapide, "
-"visible dans la barre d'état systême\n"
+msgstr ""
+"cbatticon: une icône d'affichage de la batterie, légère et rapide, visible "
+"dans la barre d'état systême\n"
 
-#: cbatticon.c:187
+#: cbatticon.c:186
 #, c-format
 msgid "version %s\n"
 msgstr "version %s\n"
 
-#: cbatticon.c:195
+#: cbatticon.c:194
 msgid "List of available power supplies:\n"
 msgstr "Liste des alimentations disponibles:\n"
 
-#: cbatticon.c:208
+#: cbatticon.c:209
 msgid "List of available icon types:\n"
 msgstr "Liste des types d'icônes disponibles:\n"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212
 msgid "available"
 msgstr "disponible"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211 cbatticon.c:539
-#: cbatticon.c:547 cbatticon.c:569
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212 cbatticon.c:540
+#: cbatticon.c:548 cbatticon.c:570
 msgid "unavailable"
 msgstr "non disponible"
 
-#: cbatticon.c:225
+#: cbatticon.c:226
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Le type d'icône: %s est inconnu\n"
 
-#: cbatticon.c:237
+#: cbatticon.c:238
 msgid "No icon type found!\n"
 msgstr "Aucun type d'icône n'a été trouvé!\n"
 
-#: cbatticon.c:244
+#: cbatticon.c:245
 #, c-format
 msgid "Invalid update interval! It has been reset to default (%d seconds)\n"
-msgstr "La fréquence de rafraichissement est invalide! Elle a été réinitialisée"
-" à la valeur par défaut (%d secondes)\n"
+msgstr ""
+"La fréquence de rafraichissement est invalide! Elle a été réinitialisée à la "
+"valeur par défaut (%d secondes)\n"
 
-#: cbatticon.c:251
+#: cbatticon.c:252
 #, c-format
 msgid "Invalid low level! It has been reset to default (%d percent)\n"
-msgstr "Le niveau de charge basse est invalide! Il a été réinitialisé à "
-"la valeur par défaut (%d pourcents)\n"
+msgstr ""
+"Le niveau de charge basse est invalide! Il a été réinitialisé à la valeur "
+"par défaut (%d pourcents)\n"
 
-#: cbatticon.c:256
+#: cbatticon.c:257
 #, c-format
 msgid "Invalid critical level! It has been reset to default (%d percent)\n"
-msgstr "Le niveau de charge critique est invalide! Il a été réinitialisé à "
-"la valeur par défaut (%d pourcents)\n"
+msgstr ""
+"Le niveau de charge critique est invalide! Il a été réinitialisé à la valeur "
+"par défaut (%d pourcents)\n"
 
-#: cbatticon.c:262
+#: cbatticon.c:263
 msgid ""
 "Critical level is higher than low level! They have been reset to default\n"
-msgstr "Le niveau de charge critique est plus grand que le niveau de charge "
-"basse! Ils ont été réinitialisés à leurs valeurs par défaut\n"
+msgstr ""
+"Le niveau de charge critique est plus grand que le niveau de charge basse! "
+"Ils ont été réinitialisés à leurs valeurs par défaut\n"
 
-#: cbatticon.c:293 cbatticon.c:325
+#: cbatticon.c:294 cbatticon.c:326
 #, c-format
 msgid "type: %-*.*s\tid: %-*.*s\tpath: %s\n"
 msgstr "type: %-*.*s\tid: %-*.*s\tchemin d'accès: %s\n"
 
-#: cbatticon.c:293
+#: cbatticon.c:294
 msgid "Battery"
 msgstr "Batterie"
 
-#: cbatticon.c:310
+#: cbatticon.c:311
 msgid "workaround: current rate is not available, estimating rate\n"
-msgstr "solution alternative: le taux de décharge instantané n'est pas disponible, une estimation est calculée\n"
+msgstr ""
+"solution alternative: le taux de décharge instantané n'est pas disponible, "
+"une estimation est calculée\n"
 
-#: cbatticon.c:315
+#: cbatticon.c:316
 #, c-format
 msgid "battery path: %s\n"
 msgstr "chemin d'accès de la batterie: %s\n"
 
-#: cbatticon.c:325
+#: cbatticon.c:326
 msgid "AC"
 msgstr "Secteur"
 
-#: cbatticon.c:333
+#: cbatticon.c:334
 #, c-format
 msgid "ac path: %s\n"
 msgstr "chemin d'accès du secteur: %s\n"
 
-#: cbatticon.c:347
+#: cbatticon.c:348
 #, c-format
 msgid "Cannot open sysfs directory: %s (%s)\n"
 msgstr "Impossible d'ouvrir le répertoire sysfs: %s (%s)\n"
 
-#: cbatticon.c:354
+#: cbatticon.c:355
 #, c-format
 msgid "No battery with suffix %s found!\n"
 msgstr "Aucune batterie avec le suffixe %s n'a été trouvée!\n"
 
-#: cbatticon.c:359
+#: cbatticon.c:360
 msgid "No battery nor AC power supply found!\n"
 msgstr "Aucune alimentation (secteur ou batterie) n'a été trouvée!\n"
 
-#: cbatticon.c:424
+#: cbatticon.c:425
 #, c-format
 msgid "battery present: %s"
 msgstr "batterie présente: %s"
 
-#: cbatticon.c:454
+#: cbatticon.c:455
 #, c-format
 msgid "battery status: %d - %s"
 msgstr "statut de la batterie: %d - %s"
 
-#: cbatticon.c:479
+#: cbatticon.c:480
 #, c-format
 msgid "ac online: %s"
 msgstr "secteur branché: %s"
 
-#: cbatticon.c:539
+#: cbatticon.c:540
 #, c-format
 msgid "full capacity: %s\n"
 msgstr "pleine capacité: %s\n"
 
-#: cbatticon.c:547
+#: cbatticon.c:548
 #, c-format
 msgid "remaining capacity: %s\n"
 msgstr "capacité restante: %s\n"
 
-#: cbatticon.c:569
+#: cbatticon.c:570
 #, c-format
 msgid "current rate: %s\n"
 msgstr "taux de décharge instantané: %s\n"
 
-#: cbatticon.c:671 cbatticon.c:674
+#: cbatticon.c:672 cbatticon.c:675
 msgid "AC only, no battery!"
 msgstr "Secteur branché, pas de batterie!"
 
-#: cbatticon.c:792
+#: cbatticon.c:793
 #, c-format
 msgid "Spawning critical battery level command in 30 seconds: %s"
-msgstr "Exécution de la commande de niveau critique de la batterie dans 30 secondes: %s"
+msgstr ""
+"Exécution de la commande de niveau critique de la batterie dans 30 secondes: "
+"%s"
 
-#: cbatticon.c:796
+#: cbatticon.c:797
 #, c-format
 msgid "Cannot spawn critical battery level command: %s"
-msgstr "Impossible d'exécuter la commande de niveau critique de la batterie: %s"
+msgstr ""
+"Impossible d'exécuter la commande de niveau critique de la batterie: %s"
 
-#: cbatticon.c:799
+#: cbatticon.c:800
 msgid "Cannot spawn critical battery level command!"
 msgstr "Impossible d'exécuter la commande de niveau critique de la batterie!"
 
-#: cbatticon.c:816
+#: cbatticon.c:817
 #, c-format
 msgid "Cannot spawn left click command: %s"
 msgstr "Impossible d'exécuter la commande de clic gauche: %s"
 
-#: cbatticon.c:819
+#: cbatticon.c:820
 msgid "Cannot spawn left click command!"
 msgstr "Impossible d'exécuter la commande de clic gauche!"
 
-#: cbatticon.c:862 cbatticon.c:870
+#: cbatticon.c:863 cbatticon.c:871
 #, c-format
 msgid "tooltip: %s\n"
 msgstr "infobulle: %s\n"
 
-#: cbatticon.c:883
+#: cbatticon.c:884
 msgid "Battery is missing!"
 msgstr "La batterie est absente!"
 
-#: cbatticon.c:887
+#: cbatticon.c:888
 msgid "Battery status is unknown!"
 msgstr "Le statut de la batterie est inconnu!"
 
-#: cbatticon.c:891
+#: cbatticon.c:892
 msgid "Battery is charged!"
 msgstr "La batterie est chargée!"
 
-#: cbatticon.c:895
-msgid "Battery is discharging (%i% remaining)"
-msgstr "Batterie en décharge (%i% restant)"
+#: cbatticon.c:896
+#, fuzzy, c-format
+msgid "Battery is discharging (%i%% remaining)"
+msgstr "Batterie en décharge (%i%% restant)"
 
-#: cbatticon.c:899
-msgid "Battery is not charging (%i% remaining)"
-msgstr "La batterie ne se charge pas (%i% restant)"
+#: cbatticon.c:900
+#, fuzzy, c-format
+msgid "Battery is not charging (%i%% remaining)"
+msgstr "La batterie ne se charge pas (%i%% restant)"
 
-#: cbatticon.c:903
-msgid "Battery level is low! (%i% remaining)"
-msgstr "Le niveau de la batterie est bas! (%i% restant)"
+#: cbatticon.c:904
+#, fuzzy, c-format
+msgid "Battery level is low! (%i%% remaining)"
+msgstr "Le niveau de la batterie est bas! (%i%% restant)"
 
-#: cbatticon.c:907
-msgid "Battery level is critical! (%i% remaining)"
-msgstr "Le niveau de la batterie est critique! (%i% restant)"
+#: cbatticon.c:908
+#, fuzzy, c-format
+msgid "Battery level is critical! (%i%% remaining)"
+msgstr "Le niveau de la batterie est critique! (%i%% restant)"
 
-#: cbatticon.c:911
-msgid "Battery is charging (%i%)"
-msgstr "Batterie en charge (%i%)"
+#: cbatticon.c:912
+#, fuzzy, c-format
+msgid "Battery is charging (%i%%)"
+msgstr "Batterie en charge (%i%%)"
 
-#: cbatticon.c:920
+#: cbatticon.c:921
 #, c-format
 msgid "battery string: %s\n"
 msgstr "message de la batterie: %s\n"
 
-#: cbatticon.c:939
-#, c-format
-msgid "%2d hours, %2d minutes remaining"
-msgstr "%2d heures, %2d minutes restantes"
-
 #: cbatticon.c:941
-#, c-format
-msgid "%2d minutes remaining"
-msgstr "%2d minutes restantes"
+#, fuzzy, c-format
+msgid "%2d minute"
+msgid_plural "%2d minutes"
+msgstr[0] "%2d minute restante"
+msgstr[1] "%2d minutes restantes"
 
-#: cbatticon.c:945
+#: cbatticon.c:942
+#, fuzzy, c-format
+msgid "%2d hour, %s remaining"
+msgid_plural "%2d hours, %s remaining"
+msgstr[0] "%2d heure, %s restantes"
+msgstr[1] "%2d heures, %s restantes"
+
+#: cbatticon.c:944
+#, fuzzy, c-format
+msgid "%2d minute remaining"
+msgid_plural "%2d minutes remaining"
+msgstr[0] "%2d minute restante"
+msgstr[1] "%2d minutes restantes"
+
+#: cbatticon.c:948
 #, c-format
 msgid "time string: %s\n"
 msgstr "message de temps: %s\n"
 
-#: cbatticon.c:993
+#: cbatticon.c:996
 #, c-format
 msgid "icon name: %s\n"
 msgstr "nom de l'icône: %s\n"

--- a/ru.po
+++ b/ru.po
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: cbatticon.c:154
 msgid "Display the version"
@@ -65,224 +66,247 @@ msgstr "Список доступных источников (батареи и 
 msgid "[BATTERY ID]"
 msgstr ""
 
-#: cbatticon.c:175
+#: cbatticon.c:174
 #, c-format
 msgid "Cannot parse command line arguments: %s\n"
 msgstr "Не удается опознать параметры строки: %s\n"
 
-#: cbatticon.c:186
+#: cbatticon.c:185
 msgid ""
 "cbatticon: a lightweight and fast battery icon that sits in your system "
 "tray\n"
 msgstr "cbatticon: индикатор значка батареи для системного трея\n"
 
-#: cbatticon.c:187
+#: cbatticon.c:186
 #, c-format
 msgid "version %s\n"
 msgstr "версия %s\n"
 
-#: cbatticon.c:195
+#: cbatticon.c:194
 msgid "List of available power supplies:\n"
 msgstr "Список доступных источников питания:\n"
 
-#: cbatticon.c:208
+#: cbatticon.c:209
 msgid "List of available icon types:\n"
 msgstr "Список доступных значков:\n"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212
 msgid "available"
 msgstr "доступно"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211 cbatticon.c:539
-#: cbatticon.c:547 cbatticon.c:569
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212 cbatticon.c:540
+#: cbatticon.c:548 cbatticon.c:570
 msgid "unavailable"
 msgstr "недоступно"
 
-#: cbatticon.c:225
+#: cbatticon.c:226
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Неизвестный тип значка: %s\n"
 
-#: cbatticon.c:237
+#: cbatticon.c:238
 msgid "No icon type found!\n"
 msgstr "Не найдены доступные значки!\n"
 
-#: cbatticon.c:244
+#: cbatticon.c:245
 #, c-format
 msgid "Invalid update interval! It has been reset to default (%d seconds)\n"
-msgstr "Неверный интервал обновления! Будет использовано значение (%d секунд)\n"
+msgstr ""
+"Неверный интервал обновления! Будет использовано значение (%d секунд)\n"
 
-#: cbatticon.c:251
+#: cbatticon.c:252
 #, c-format
 msgid "Invalid low level! It has been reset to default (%d percent)\n"
 msgstr "Неверный низкий уровень! Будет использовано значение (%d процентов)\n"
 
-#: cbatticon.c:256
+#: cbatticon.c:257
 #, c-format
 msgid "Invalid critical level! It has been reset to default (%d percent)\n"
-msgstr "Неверный критический уровень! Будет использовано значение (%d процентов)\n"
+msgstr ""
+"Неверный критический уровень! Будет использовано значение (%d процентов)\n"
 
-#: cbatticon.c:262
+#: cbatticon.c:263
 msgid ""
 "Critical level is higher than low level! They have been reset to default\n"
-msgstr "Критический уровень больше чем низкий уровень! Будут использованы значения по-умолчанию\n"
+msgstr ""
+"Критический уровень больше чем низкий уровень! Будут использованы значения "
+"по-умолчанию\n"
 
-#: cbatticon.c:293 cbatticon.c:325
+#: cbatticon.c:294 cbatticon.c:326
 #, c-format
 msgid "type: %-*.*s\tid: %-*.*s\tpath: %s\n"
 msgstr ""
 
-#: cbatticon.c:293
+#: cbatticon.c:294
 msgid "Battery"
 msgstr ""
 
-#: cbatticon.c:310
+#: cbatticon.c:311
 msgid "workaround: current rate is not available, estimating rate\n"
 msgstr ""
 
-#: cbatticon.c:315
+#: cbatticon.c:316
 #, c-format
 msgid "battery path: %s\n"
 msgstr ""
 
-#: cbatticon.c:325
+#: cbatticon.c:326
 msgid "AC"
 msgstr ""
 
-#: cbatticon.c:333
+#: cbatticon.c:334
 #, c-format
 msgid "ac path: %s\n"
 msgstr ""
 
-#: cbatticon.c:347
+#: cbatticon.c:348
 #, c-format
 msgid "Cannot open sysfs directory: %s (%s)\n"
 msgstr "Не удается открыть каталог sysfs: %s (%s)\n"
 
-#: cbatticon.c:354
+#: cbatticon.c:355
 #, c-format
 msgid "No battery with suffix %s found!\n"
 msgstr "Батарея %s не найдена!\n"
 
-#: cbatticon.c:359
+#: cbatticon.c:360
 msgid "No battery nor AC power supply found!\n"
 msgstr ""
 
-#: cbatticon.c:424
+#: cbatticon.c:425
 #, c-format
 msgid "battery present: %s"
 msgstr ""
 
-#: cbatticon.c:454
+#: cbatticon.c:455
 #, c-format
 msgid "battery status: %d - %s"
 msgstr ""
 
-#: cbatticon.c:479
+#: cbatticon.c:480
 #, c-format
 msgid "ac online: %s"
 msgstr ""
 
-#: cbatticon.c:539
+#: cbatticon.c:540
 #, c-format
 msgid "full capacity: %s\n"
 msgstr ""
 
-#: cbatticon.c:547
+#: cbatticon.c:548
 #, c-format
 msgid "remaining capacity: %s\n"
 msgstr ""
 
-#: cbatticon.c:569
+#: cbatticon.c:570
 #, c-format
 msgid "current rate: %s\n"
 msgstr ""
 
-#: cbatticon.c:671 cbatticon.c:674
+#: cbatticon.c:672 cbatticon.c:675
 msgid "AC only, no battery!"
 msgstr "От сети, нет батареи!"
 
-#: cbatticon.c:792
+#: cbatticon.c:793
 #, c-format
 msgid "Spawning critical battery level command in 30 seconds: %s"
 msgstr ""
 
-#: cbatticon.c:796
+#: cbatticon.c:797
 #, c-format
 msgid "Cannot spawn critical battery level command: %s"
 msgstr ""
 
-#: cbatticon.c:799
+#: cbatticon.c:800
 msgid "Cannot spawn critical battery level command!"
 msgstr "Невозможно выполнить команду для критического уровня!"
 
-#: cbatticon.c:816
+#: cbatticon.c:817
 #, c-format
 msgid "Cannot spawn left click command: %s"
 msgstr ""
 
-#: cbatticon.c:819
+#: cbatticon.c:820
 msgid "Cannot spawn left click command!"
 msgstr "Невозможно выполнить команду для левой кнопки мыши!"
 
-#: cbatticon.c:862 cbatticon.c:870
+#: cbatticon.c:863 cbatticon.c:871
 #, c-format
 msgid "tooltip: %s\n"
 msgstr ""
 
-#: cbatticon.c:883
+#: cbatticon.c:884
 msgid "Battery is missing!"
 msgstr "Батарея отсутствует!"
 
-#: cbatticon.c:887
+#: cbatticon.c:888
 msgid "Battery status is unknown!"
 msgstr "Статус батареи неизвестен!"
 
-#: cbatticon.c:891
+#: cbatticon.c:892
 msgid "Battery is charged!"
 msgstr "Батарея заряжена!"
 
-#: cbatticon.c:895
-msgid "Battery is discharging (%i% remaining)"
-msgstr "Батарея разряжается (%i% осталось)"
+#: cbatticon.c:896
+#, fuzzy, c-format
+msgid "Battery is discharging (%i%% remaining)"
+msgstr "Батарея разряжается (%i%% осталось)"
 
-#: cbatticon.c:899
-msgid "Battery is not charging (%i% remaining)"
-msgstr "Батарея не заряжается (%i% осталось)"
+#: cbatticon.c:900
+#, fuzzy, c-format
+msgid "Battery is not charging (%i%% remaining)"
+msgstr "Батарея не заряжается (%i%% осталось)"
 
-#: cbatticon.c:903
-msgid "Battery level is low! (%i% remaining)"
-msgstr "Низкий уровень заряда батареи! (%i% осталось)"
+#: cbatticon.c:904
+#, fuzzy, c-format
+msgid "Battery level is low! (%i%% remaining)"
+msgstr "Низкий уровень заряда батареи! (%i%% осталось)"
 
-#: cbatticon.c:907
-msgid "Battery level is critical! (%i% remaining)"
-msgstr "Критический уровень заряда батареи! (%i% осталось)"
+#: cbatticon.c:908
+#, fuzzy, c-format
+msgid "Battery level is critical! (%i%% remaining)"
+msgstr "Критический уровень заряда батареи! (%i%% осталось)"
 
-#: cbatticon.c:911
-msgid "Battery is charging (%i%)"
-msgstr "Батарея заряжается (%i%)"
+#: cbatticon.c:912
+#, fuzzy, c-format
+msgid "Battery is charging (%i%%)"
+msgstr "Батарея заряжается (%i%%)"
 
-#: cbatticon.c:920
+#: cbatticon.c:921
 #, c-format
 msgid "battery string: %s\n"
 msgstr ""
 
-#: cbatticon.c:939
-#, c-format
-msgid "%2d hours, %2d minutes remaining"
-msgstr "%2d часов, %2d минут осталось"
-
 #: cbatticon.c:941
-#, c-format
-msgid "%2d minutes remaining"
-msgstr "%2d минут осталось"
+#, fuzzy, c-format
+msgid "%2d minute"
+msgid_plural "%2d minutes"
+msgstr[0] "%2d минута"
+msgstr[1] "%2d минуты"
+msgstr[2] "%2d минут"
 
-#: cbatticon.c:945
+#: cbatticon.c:942
+#, fuzzy, c-format
+msgid "%2d hour, %s remaining"
+msgid_plural "%2d hours, %s remaining"
+msgstr[0] "%2d час, %s осталось"
+msgstr[1] "%2d часа, %s осталось"
+msgstr[2] "%2d часов, %s осталось"
+
+#: cbatticon.c:944
+#, fuzzy, c-format
+msgid "%2d minute remaining"
+msgid_plural "%2d minutes remaining"
+msgstr[0] "%2d минута осталось"
+msgstr[1] "%2d минуты осталось"
+msgstr[2] "%2d минут осталось"
+
+#: cbatticon.c:948
 #, c-format
 msgid "time string: %s\n"
 msgstr ""
 
-#: cbatticon.c:993
+#: cbatticon.c:996
 #, c-format
 msgid "icon name: %s\n"
 msgstr ""

--- a/tr.po
+++ b/tr.po
@@ -11,12 +11,13 @@ msgstr ""
 "PO-Revision-Date: 2015-07-19 14:11+0200\n"
 "Last-Translator: Behzat Erte <behzaterte@yandex.com>\n"
 "Language-Team: TR <behzaterte@yandex.com>\n"
+"Language: Turkish\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.5\n"
-"Language: Turkish\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
 
 #: cbatticon.c:154
 msgid "Display the version"
@@ -66,224 +67,241 @@ msgstr "Kullanılabilir güç kaynaklarını listele (pil ve şebeke)"
 msgid "[BATTERY ID]"
 msgstr "[PİL ID]"
 
-#: cbatticon.c:175
+#: cbatticon.c:174
 #, c-format
 msgid "Cannot parse command line arguments: %s\n"
 msgstr "Komut satırı değişkenleri ayrıştırılamıyor: %s\n"
 
-#: cbatticon.c:186
+#: cbatticon.c:185
 msgid ""
 "cbatticon: a lightweight and fast battery icon that sits in your system "
 "tray\n"
 msgstr "cbatticon: sistem çekmecesinde görünen küçük ve hızlı pil simgesi\n"
 
-#: cbatticon.c:187
+#: cbatticon.c:186
 #, c-format
 msgid "version %s\n"
 msgstr "sürüm %s\n"
 
-#: cbatticon.c:195
+#: cbatticon.c:194
 msgid "List of available power supplies:\n"
 msgstr "Uygun güç kaynaklarının listesi:\n"
 
-#: cbatticon.c:208
+#: cbatticon.c:209
 msgid "List of available icon types:\n"
 msgstr "Uygun simge türlerinin listesi:\n"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212
 msgid "available"
 msgstr "uygun"
 
-#: cbatticon.c:209 cbatticon.c:210 cbatticon.c:211 cbatticon.c:539
-#: cbatticon.c:547 cbatticon.c:569
+#: cbatticon.c:210 cbatticon.c:211 cbatticon.c:212 cbatticon.c:540
+#: cbatticon.c:548 cbatticon.c:570
 msgid "unavailable"
 msgstr "uygun değil"
 
-#: cbatticon.c:225
+#: cbatticon.c:226
 #, c-format
 msgid "Unknown icon type: %s\n"
 msgstr "Bilinmeyen simge türü: %s\n"
 
-#: cbatticon.c:237
+#: cbatticon.c:238
 msgid "No icon type found!\n"
 msgstr "Hiç simge türü bulunamadı!\n"
 
-#: cbatticon.c:244
+#: cbatticon.c:245
 #, c-format
 msgid "Invalid update interval! It has been reset to default (%d seconds)\n"
 msgstr "Geçersiz güncelleme aralığı! Varsayılan ayarlara dönecek (%d saniye)\n"
 
-#: cbatticon.c:251
+#: cbatticon.c:252
 #, c-format
 msgid "Invalid low level! It has been reset to default (%d percent)\n"
 msgstr "Geçersiz alt seviye! Varsayılan ayarlara dönecek (yüzde %d)\n"
 
-#: cbatticon.c:256
+#: cbatticon.c:257
 #, c-format
 msgid "Invalid critical level! It has been reset to default (%d percent)\n"
 msgstr "Geçersiz kritik seviye! Varsayılan ayarlara dönecek (yüzde %d)\n"
 
-#: cbatticon.c:262
+#: cbatticon.c:263
 msgid ""
 "Critical level is higher than low level! They have been reset to default\n"
-msgstr "Kritik seviye alt seviyeden yüksek! Varsayılan ayarlarına döndürülecekler\n"
+msgstr ""
+"Kritik seviye alt seviyeden yüksek! Varsayılan ayarlarına döndürülecekler\n"
 
-#: cbatticon.c:293 cbatticon.c:325
+#: cbatticon.c:294 cbatticon.c:326
 #, c-format
 msgid "type: %-*.*s\tid: %-*.*s\tpath: %s\n"
 msgstr "tür: %-*.*s\tid: %-*.*s\tyol: %s\n"
 
-#: cbatticon.c:293
+#: cbatticon.c:294
 msgid "Battery"
 msgstr "Pil"
 
-#: cbatticon.c:310
+#: cbatticon.c:311
 msgid "workaround: current rate is not available, estimating rate\n"
 msgstr "geçici çözüm: güncel değer uygun değil, değer tahmin ediliyor\n"
 
-#: cbatticon.c:315
+#: cbatticon.c:316
 #, c-format
 msgid "battery path: %s\n"
 msgstr "pil yolu: %s\n"
 
-#: cbatticon.c:325
+#: cbatticon.c:326
 msgid "AC"
 msgstr "Şebeke"
 
-#: cbatticon.c:333
+#: cbatticon.c:334
 #, c-format
 msgid "ac path: %s\n"
 msgstr "şebeke yolu: %s\n"
 
-#: cbatticon.c:347
+#: cbatticon.c:348
 #, c-format
 msgid "Cannot open sysfs directory: %s (%s)\n"
 msgstr "sysfs klasörü açılamıyor: %s (%s)\n"
 
-#: cbatticon.c:354
+#: cbatticon.c:355
 #, c-format
 msgid "No battery with suffix %s found!\n"
 msgstr "Pil ile eki %s bulunamadı!\n"
 
-#: cbatticon.c:359
+#: cbatticon.c:360
 msgid "No battery nor AC power supply found!\n"
 msgstr "Pil ya da şebeke güç ünitesi bulunamadı!\n"
 
-#: cbatticon.c:424
+#: cbatticon.c:425
 #, c-format
 msgid "battery present: %s"
 msgstr "pil gösterimi: %s"
 
-#: cbatticon.c:454
+#: cbatticon.c:455
 #, c-format
 msgid "battery status: %d - %s"
 msgstr "pil durumu: %d - %s"
 
-#: cbatticon.c:479
+#: cbatticon.c:480
 #, c-format
 msgid "ac online: %s"
 msgstr "şebeke çevrimiçi: %s"
 
-#: cbatticon.c:539
+#: cbatticon.c:540
 #, c-format
 msgid "full capacity: %s\n"
 msgstr "tam kapasite: %s\n"
 
-#: cbatticon.c:547
+#: cbatticon.c:548
 #, c-format
 msgid "remaining capacity: %s\n"
 msgstr "kalan güç: %s\n"
 
-#: cbatticon.c:569
+#: cbatticon.c:570
 #, c-format
 msgid "current rate: %s\n"
 msgstr "güncel değer: %s\n"
 
-#: cbatticon.c:671 cbatticon.c:674
+#: cbatticon.c:672 cbatticon.c:675
 msgid "AC only, no battery!"
 msgstr "Sadece şebeke, pil yok!"
 
-#: cbatticon.c:792
+#: cbatticon.c:793
 #, c-format
 msgid "Spawning critical battery level command in 30 seconds: %s"
 msgstr "Kritik pil seviyesi komutu 30 saniye içerisinde üretilecek: %s"
 
-#: cbatticon.c:796
+#: cbatticon.c:797
 #, c-format
 msgid "Cannot spawn critical battery level command: %s"
 msgstr "Kritik seviye komutu üretilemiyor: %s"
 
-#: cbatticon.c:799
+#: cbatticon.c:800
 msgid "Cannot spawn critical battery level command!"
 msgstr "Kritik pil seviyesi komutu oluşturulamıyor!"
 
-#: cbatticon.c:816
+#: cbatticon.c:817
 #, c-format
 msgid "Cannot spawn left click command: %s"
 msgstr "Sol tuş komutu üretilemiyor: %s"
 
-#: cbatticon.c:819
+#: cbatticon.c:820
 msgid "Cannot spawn left click command!"
 msgstr "Sol tuş komutu oluşturulamıyor!"
 
-#: cbatticon.c:862 cbatticon.c:870
+#: cbatticon.c:863 cbatticon.c:871
 #, c-format
 msgid "tooltip: %s\n"
 msgstr "araç bilgisi: %s\n"
 
-#: cbatticon.c:883
+#: cbatticon.c:884
 msgid "Battery is missing!"
 msgstr "Pil kayıp!"
 
-#: cbatticon.c:887
+#: cbatticon.c:888
 msgid "Battery status is unknown!"
 msgstr "Pil durumu bilinmiyor!"
 
-#: cbatticon.c:891
+#: cbatticon.c:892
 msgid "Battery is charged!"
 msgstr "Pil dolduruldu!"
 
-#: cbatticon.c:895
-msgid "Battery is discharging (%i% remaining)"
-msgstr "Pil boşalıyor (%i% kalan)"
+#: cbatticon.c:896
+#, fuzzy, c-format
+msgid "Battery is discharging (%i%% remaining)"
+msgstr "Pil boşalıyor (%i%% kalan)"
 
-#: cbatticon.c:899
-msgid "Battery is not charging (%i% remaining)"
-msgstr "Pil doldurulmuyor (%i% kalan)"
+#: cbatticon.c:900
+#, fuzzy, c-format
+msgid "Battery is not charging (%i%% remaining)"
+msgstr "Pil doldurulmuyor (%i%% kalan)"
 
-#: cbatticon.c:903
-msgid "Battery level is low! (%i% remaining)"
-msgstr "Pil durumu düşük! (%i% kalan)"
+#: cbatticon.c:904
+#, fuzzy, c-format
+msgid "Battery level is low! (%i%% remaining)"
+msgstr "Pil durumu düşük! (%i%% kalan)"
 
-#: cbatticon.c:907
-msgid "Battery level is critical! (%i% remaining)"
-msgstr "Pil kritik seviyede! (%i% kalan)"
+#: cbatticon.c:908
+#, fuzzy, c-format
+msgid "Battery level is critical! (%i%% remaining)"
+msgstr "Pil kritik seviyede! (%i%% kalan)"
 
-#: cbatticon.c:911
-msgid "Battery is charging (%i%)"
-msgstr "Pil dolduruluyor (%i%)"
+#: cbatticon.c:912
+#, fuzzy, c-format
+msgid "Battery is charging (%i%%)"
+msgstr "Pil dolduruluyor (%i%%)"
 
-#: cbatticon.c:920
+#: cbatticon.c:921
 #, c-format
 msgid "battery string: %s\n"
 msgstr "pil metni: %s\n"
 
-#: cbatticon.c:939
-#, c-format
-msgid "%2d hours, %2d minutes remaining"
-msgstr "%2d saat, %2d dakika kaldı"
-
 #: cbatticon.c:941
-#, c-format
-msgid "%2d minutes remaining"
-msgstr "%2d dakika kaldı"
+#, fuzzy, c-format
+msgid "%2d minute"
+msgid_plural "%2d minutes"
+msgstr[0] "%2d dakika kaldı"
+msgstr[1] "%2d dakikalar kaldı"
 
-#: cbatticon.c:945
+#: cbatticon.c:942
+#, fuzzy, c-format
+msgid "%2d hour, %s remaining"
+msgid_plural "%2d hours, %s remaining"
+msgstr[0] "%2d saat, %s kaldı"
+msgstr[1] "%2d saatler, %s kaldı"
+
+#: cbatticon.c:944
+#, fuzzy, c-format
+msgid "%2d minute remaining"
+msgid_plural "%2d minutes remaining"
+msgstr[0] "%2d dakika kaldı"
+msgstr[1] "%2d dakikalar kaldı"
+
+#: cbatticon.c:948
 #, c-format
 msgid "time string: %s\n"
 msgstr "zaman metni: %s\n"
 
-#: cbatticon.c:993
+#: cbatticon.c:996
 #, c-format
 msgid "icon name: %s\n"
 msgstr "simge adı: %s\n"


### PR DESCRIPTION
These strings now use ngettext instead of gettext. I only fluently speak French and English, so, I can't 100% verify the other languages, but I used the right plural forms and did a tiny bit of research and it's definitely better than before.