### PR TITLE
Avoid duplicate notifications on startup

### DIFF
--- a/cbatticon.c
+++ b/cbatticon.c
@@ -1113,6 +1113,7 @@ int main (int argc, char **argv)
         battery_suffix = argv[1];
     }
 
+    get_power_supplies();
     create_tray_icon ();
     gtk_main();
 


### PR DESCRIPTION
During startup, ac_path and battery_path were not initialized. This ultimately lead to a duplicate notification, since changed_power_supplies returned incorrect information in the very first call.

Fixes #38.