### PR TITLE
If last_chance option true, check one last time if charging before running critical

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,7 @@ Application Options:
   -i, --icon-type                  Set icon type ('standard', 'notification' or 'symbolic')
   -l, --low-level                  Set low battery level (in percent)
   -r, --critical-level             Set critical battery level (in percent)
+  --last-chance                    Check 30 seconds after critical if battery is charging
   -c, --command-critical-level     Command to execute when critical battery level is reached
   -x, --command-left-click         Command to execute when left clicking on tray icon
   -n, --hide-notification          Hide the notification popups
@@ -35,6 +36,7 @@ Default value for options:
                            (check your setup with --list-icon-types)
   low level              : 20 percent
   critical level         : 5 percent
+  last chance            : false
   command critical level : none
   command left click     : none
   battery id             : the first one that is reported by sysfs

--- a/cbatticon.c
+++ b/cbatticon.c
@@ -110,6 +110,7 @@ struct configuration {
     gint     icon_type;
     gint     low_level;
     gint     critical_level;
+    gboolean last_chance;
     gchar   *command_critical_level;
     gchar   *command_left_click;
 #ifdef WITH_NOTIFY
@@ -124,6 +125,7 @@ struct configuration {
     UNKNOWN_ICON,
     DEFAULT_LOW_LEVEL,
     DEFAULT_CRITICAL_LEVEL,
+    FALSE,
     NULL,
     NULL,
 #ifdef WITH_NOTIFY
@@ -164,6 +166,7 @@ static gint get_options (int argc, char **argv)
         { "icon-type"             , 'i', 0, G_OPTION_ARG_STRING, &icon_type_string                    , N_("Set icon type ('standard', 'notification' or 'symbolic')") , NULL },
         { "low-level"             , 'l', 0, G_OPTION_ARG_INT   , &configuration.low_level             , N_("Set low battery level (in percent)")                       , NULL },
         { "critical-level"        , 'r', 0, G_OPTION_ARG_INT   , &configuration.critical_level        , N_("Set critical battery level (in percent)")                  , NULL },
+        { "last-chance"           ,   0, 0, G_OPTION_ARG_NONE  , &configuration.last_chance           , N_("Check 30 seconds after critical if battery is charging")   , NULL },
         { "command-critical-level", 'c', 0, G_OPTION_ARG_STRING, &configuration.command_critical_level, N_("Command to execute when critical battery level is reached"), NULL },
         { "command-left-click"    , 'x', 0, G_OPTION_ARG_STRING, &configuration.command_left_click    , N_("Command to execute when left clicking on tray icon")       , NULL },
 #ifdef WITH_NOTIFY

--- a/cbatticon.c
+++ b/cbatticon.c
@@ -893,6 +893,12 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
                     syslog (LOG_CRIT, _("Spawning critical battery level command in 30 seconds: %s"), configuration.command_critical_level);
                     g_usleep (G_USEC_PER_SEC * 30);
 
+                    if (configuration.last_chance && get_battery_status (&battery_status) == TRUE) {
+                        if (battery_status != DISCHARGING && battery_status != NOT_CHARGING) {
+                            syslog (LOG_NOTICE, _("Skipping critical battery level command, no longer discharging."));
+                            return;
+                        }
+                    }
                     if (g_spawn_command_line_async (configuration.command_critical_level, &error) == FALSE) {
                         syslog (LOG_CRIT, _("Cannot spawn critical battery level command: %s\n"), error->message);
 


### PR DESCRIPTION
Hi! This solves a little frustration of mine with `cbatticon`. That I get the notification critical battery level reached and am quick enough to plug in my charger but after the 30 seconds, my hibernate command is executed anyway.
What do you think? Not sure if the option is even necessary but I wasn't sure about changing the default behavior.