### PR TITLE
Use system default Icons and Theme

### DIFF
--- a/cbatticon.c
+++ b/cbatticon.c
@@ -60,10 +60,11 @@ static gboolean get_battery_charge (gboolean remaining, gint *percentage, gint *
 static gboolean get_battery_time_estimation (gdouble remaining_capacity, gdouble y, gint *time);
 static void reset_battery_time_estimation (void);
 
+struct icon_data;
 static void create_tray_icon (void);
-static gboolean update_tray_icon (GtkStatusIcon *tray_icon);
-static void update_tray_icon_status (GtkStatusIcon *tray_icon);
-static void on_tray_icon_click (GtkStatusIcon *tray_icon, gpointer user_data);
+static gboolean update_tray_icon (struct icon_data *tray_icon);
+static void update_tray_icon_status (struct icon_data *tray_icon);
+static void on_tray_icon_click (struct icon_data *tray_icon, gpointer user_data);
 
 #ifdef WITH_NOTIFY
 static void notify_message (NotifyNotification **notification, gchar *summary, gchar *body, gint timeout, NotifyUrgency urgency);
@@ -696,29 +697,54 @@ static void reset_battery_time_estimation (void)
  * tray icon functions
  */
 
-static void set_icon(GtkStatusIcon *tray_icon, const gchar* name) {
+struct icon_data {
+    GtkStatusIcon *gtk_icon;
+    gchar *name;
+    gint size;
+};
+
+static void set_tray_icon(struct icon_data *tray_icon, const gchar* name) {
+    gint size = gtk_status_icon_get_size(tray_icon->gtk_icon);
+    if (size == tray_icon->size && (!name || !strcmp(name, tray_icon->name)))
+    {
+        return;
+    }
+    tray_icon->size = size;
+    if (name)
+    {
+        g_free(tray_icon->name);
+        tray_icon->name = g_strdup(name);
+    }
+
     GdkPixbuf *pix = gtk_icon_theme_load_icon(gtk_icon_theme_get_default(),
-                                              name,
-                                              32,
+                                              tray_icon->name,
+                                              tray_icon->size,
                                               GTK_ICON_LOOKUP_USE_BUILTIN,
                                               NULL);
-    gtk_status_icon_set_from_pixbuf(tray_icon, pix);
+    gtk_status_icon_set_from_pixbuf(tray_icon->gtk_icon, pix);
 }
 
+static void resize_tray_icon(GtkStatusIcon *_, gint size, struct icon_data *tray_icon) {
+    set_tray_icon(tray_icon, NULL);
+}
 
 static void create_tray_icon (void)
 {
-    GtkStatusIcon *tray_icon = gtk_status_icon_new ();
+    struct icon_data* tray_icon = g_malloc (sizeof(*tray_icon));
+    tray_icon->gtk_icon = gtk_status_icon_new ();
+    tray_icon->name = g_strdup("");
+    tray_icon->size = 0;
 
-    gtk_status_icon_set_tooltip_text (tray_icon, CBATTICON_STRING);
-    gtk_status_icon_set_visible (tray_icon, TRUE);
+    gtk_status_icon_set_tooltip_text (tray_icon->gtk_icon, CBATTICON_STRING);
+    gtk_status_icon_set_visible (tray_icon->gtk_icon, TRUE);
 
     update_tray_icon (tray_icon);
     g_timeout_add_seconds (configuration.update_interval, (GSourceFunc)update_tray_icon, (gpointer)tray_icon);
-    g_signal_connect (G_OBJECT (tray_icon), "activate", G_CALLBACK (on_tray_icon_click), NULL);
+    g_signal_connect (G_OBJECT (tray_icon->gtk_icon), "size-changed", G_CALLBACK (resize_tray_icon), (gpointer) tray_icon);
+    g_signal_connect (G_OBJECT (tray_icon->gtk_icon), "activate", G_CALLBACK (on_tray_icon_click), NULL);
 }
 
-static gboolean update_tray_icon (GtkStatusIcon *tray_icon)
+static gboolean update_tray_icon (struct icon_data *tray_icon)
 {
     g_return_val_if_fail (tray_icon != NULL, FALSE);
 
@@ -727,7 +753,7 @@ static gboolean update_tray_icon (GtkStatusIcon *tray_icon)
     return TRUE;
 }
 
-static void update_tray_icon_status (GtkStatusIcon *tray_icon)
+static void update_tray_icon_status (struct icon_data *tray_icon)
 {
     GError *error = NULL;
 
@@ -776,8 +802,8 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
 
             NOTIFY_MESSAGE (&notification, _("AC only, no battery!"), NULL, NOTIFY_EXPIRES_NEVER, NOTIFY_URGENCY_NORMAL);
 
-            gtk_status_icon_set_tooltip_text (tray_icon, _("AC only, no battery!"));
-            set_icon (tray_icon, "ac-adapter");
+            gtk_status_icon_set_tooltip_text (tray_icon->gtk_icon, _("AC only, no battery!"));
+            set_tray_icon (tray_icon, "ac-adapter");
         }
 
         return;
@@ -824,8 +850,8 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
                 NOTIFY_MESSAGE (&notification, battery_string, time_string, EXP, URG);                      \
             }                                                                                               \
                                                                                                             \
-            gtk_status_icon_set_tooltip_text (tray_icon, get_tooltip_string (battery_string, time_string)); \
-            set_icon (tray_icon, get_icon_name (battery_status, percentage));
+            gtk_status_icon_set_tooltip_text (tray_icon->gtk_icon, get_tooltip_string (battery_string, time_string)); \
+            set_tray_icon (tray_icon, get_icon_name (battery_status, percentage));
 
     switch (battery_status) {
         case MISSING:
@@ -890,8 +916,8 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
                 spawn_command_critical = TRUE;
             }
 
-            gtk_status_icon_set_tooltip_text (tray_icon, get_tooltip_string (battery_string, time_string));
-            set_icon (tray_icon, get_icon_name (battery_status, percentage));
+            gtk_status_icon_set_tooltip_text (tray_icon->gtk_icon, get_tooltip_string (battery_string, time_string));
+            set_tray_icon (tray_icon, get_icon_name (battery_status, percentage));
 
             if (spawn_command_critical == TRUE) {
                 spawn_command_critical = FALSE;
@@ -924,7 +950,7 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
     }
 }
 
-static void on_tray_icon_click (GtkStatusIcon *tray_icon, gpointer user_data)
+static void on_tray_icon_click (struct icon_data *tray_icon, gpointer user_data)
 {
     GError *error = NULL;
 

--- a/cbatticon.c
+++ b/cbatticon.c
@@ -696,6 +696,16 @@ static void reset_battery_time_estimation (void)
  * tray icon functions
  */
 
+static void set_icon(GtkStatusIcon *tray_icon, const gchar* name) {
+    GdkPixbuf *pix = gtk_icon_theme_load_icon(gtk_icon_theme_get_default(),
+                                              name,
+                                              32,
+                                              GTK_ICON_LOOKUP_USE_BUILTIN,
+                                              NULL);
+    gtk_status_icon_set_from_pixbuf(tray_icon, pix);
+}
+
+
 static void create_tray_icon (void)
 {
     GtkStatusIcon *tray_icon = gtk_status_icon_new ();
@@ -767,7 +777,7 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
             NOTIFY_MESSAGE (&notification, _("AC only, no battery!"), NULL, NOTIFY_EXPIRES_NEVER, NOTIFY_URGENCY_NORMAL);
 
             gtk_status_icon_set_tooltip_text (tray_icon, _("AC only, no battery!"));
-            gtk_status_icon_set_from_icon_name (tray_icon, "ac-adapter");
+            set_icon (tray_icon, "ac-adapter");
         }
 
         return;
@@ -815,7 +825,7 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
             }                                                                                               \
                                                                                                             \
             gtk_status_icon_set_tooltip_text (tray_icon, get_tooltip_string (battery_string, time_string)); \
-            gtk_status_icon_set_from_icon_name (tray_icon, get_icon_name (battery_status, percentage));
+            set_icon (tray_icon, get_icon_name (battery_status, percentage));
 
     switch (battery_status) {
         case MISSING:
@@ -881,7 +891,7 @@ static void update_tray_icon_status (GtkStatusIcon *tray_icon)
             }
 
             gtk_status_icon_set_tooltip_text (tray_icon, get_tooltip_string (battery_string, time_string));
-            gtk_status_icon_set_from_icon_name (tray_icon, get_icon_name (battery_status, percentage));
+            set_icon (tray_icon, get_icon_name (battery_status, percentage));
 
             if (spawn_command_critical == TRUE) {
                 spawn_command_critical = FALSE;


### PR DESCRIPTION
Currently cbatticon does not use the system configured Icons and Theme (.config/gtk-3.0/settings.ini). On my system this has the effect, that icons appear in the wrong color (dark icon on dark background).

Switching from `gtk_status_icon_set_from_icon_name` to `use system default icons` + `use system default icons` solves this problem.