### PR TITLE
Add Ayatana AppIndicator support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ WITH_GTK3 = 1
 ### libnotify support: 0 for off, 1 for on (default: on)
 WITH_NOTIFY = 1
 
+### libappindicator support: 0 for off, 1 for on (default: on)
+WITH_APPINDICATOR = 1
+
 # programs
 
 CC ?= gcc
@@ -48,6 +51,9 @@ endif
 ifeq ($(WITH_NOTIFY),1)
 CPPFLAGS += -DWITH_NOTIFY
 endif
+ifeq ($(WITH_APPINDICATOR),1)
+CPPFLAGS += -DWITH_APPINDICATOR
+endif
 CPPFLAGS += -DNLSDIR=\"$(NLSDIR)\"
 
 CFLAGS ?= -O2
@@ -62,6 +68,9 @@ endif
 
 ifeq ($(WITH_NOTIFY),1)
 PKG_DEPS += libnotify
+endif
+ifeq ($(WITH_APPINDICATOR),1)
+PKG_DEPS += ayatana-appindicator3-0.1
 endif
 
 LIBS += $(shell $(PKG_CONFIG) --libs $(PKG_DEPS)) -lm

--- a/README
+++ b/README
@@ -9,6 +9,9 @@ Make options:
   WITH_NOTIFY=1 to build with libnotify support, it is the default option
   WITH_NOTIFY=0 to build without libnotify support
 
+  WITH_APPINDICATOR=1 to build with ayatana-appindicator support, it is the default option
+  WITH_APPINDICATOR=0 to build without ayatana-appindicator support
+
 Usage:
   cbatticon [OPTION...] [BATTERY ID]
 


### PR DESCRIPTION
This PR introduces support for Ayatana AppIndicator in `cbatticon`. This enhancement addresses a specific issue where GtkIcon tray apps are not displayed in some scenarios (e.g., with Waybar; see #74 for details).

This PR does not replace GtkIcon but provides the option to choose between Ayatana AppIndicator (enabled with `WITH_APPINDICATOR`) and GtkIcon through preprocessors. This approach is similar to how LIBNOTIFY is currently handled.

However, there is a known limitation with Ayatana AppIndicator: it does not support click events (see [AyatanaIndicators/libayatana-appindicator#4](https://github.com/AyatanaIndicators/libayatana-appindicator/issues/4)), required for left-click functionality. To work around this, the current implementation take advantage of the fact that a menu is necessary to have an indicator in ayatana, so I decided to use it to display those actions, this as a temporary measure until Ayatana adds support for click events.
![cbatticon_appindicator](https://github.com/user-attachments/assets/b54f8167-796b-4487-898d-8fa8f1ac928c)